### PR TITLE
Feature: Add ceph maintenance support

### DIFF
--- a/.changelogs/0.1.4/3-add-ceph-maintenance-support.yml
+++ b/.changelogs/0.1.4/3-add-ceph-maintenance-support.yml
@@ -1,0 +1,2 @@
+added:
+  - Add Ceph OSD maintenance support (@gyptazy). [#3]

--- a/proxpatch/src/main.rs
+++ b/proxpatch/src/main.rs
@@ -8,6 +8,7 @@ mod migrate;
 mod models;
 mod nodes;
 mod patch;
+mod utils_ceph;
 mod utils_proxlb;
 mod version;
 mod vms;
@@ -28,6 +29,9 @@ use crate::patch::exec_upgrade;
 use crate::patch::val_reboot;
 use crate::patch::exec_enable_maintenance;
 use crate::patch::exec_disable_maintenance;
+use crate::utils_ceph::exec_enable_ceph_maintenance;
+use crate::utils_ceph::exec_disable_ceph_maintenance;
+use crate::utils_ceph::exec_check_ceph_mon_ok_to_stop;
 use crate::utils_proxlb::is_package_proxlb_installed;
 use crate::utils_proxlb::set_systemd_proxlb;
 use log::{info, debug, warn, error};
@@ -165,14 +169,15 @@ fn run_proxpatch(cli: &Cli) -> Result<(), Box<dyn std::error::Error>> {
 
         let ssh_target = cluster.get(&node_name).and_then(|d| d.resources.ip.as_deref()).unwrap_or(&node_name);
 
+        exec_check_ceph_mon_ok_to_stop(user, ssh_target, &node_name)?;
+        exec_enable_ceph_maintenance(user, ssh_target, &node_name)?;
         exec_enable_maintenance(user, ssh_target, &node_name)?;
-        std::thread::sleep(std::time::Duration::from_secs(30));
-
+        std::thread::sleep(std::time::Duration::from_secs(60));
         exec_reboot(user, ssh_target)?;
-        std::thread::sleep(std::time::Duration::from_secs(120));
-
+        std::thread::sleep(std::time::Duration::from_secs(240));
         exec_disable_maintenance(user, ssh_target, &node_name)?;
-        std::thread::sleep(std::time::Duration::from_secs(30));
+        exec_disable_ceph_maintenance(user, ssh_target, &node_name)?;
+        std::thread::sleep(std::time::Duration::from_secs(60));
 
         if !wait_for_node_online(&node_name, 30)? {
             error!("Node {} did not come back online in time", node_name);

--- a/proxpatch/src/utils_ceph.rs
+++ b/proxpatch/src/utils_ceph.rs
@@ -1,1 +1,181 @@
-//
+use std::process::Command;
+use log::{debug, error, info};
+
+pub fn exec_enable_ceph_maintenance(user: &str, ssh_target: &str, node_name: &str) -> Result<(), Box<dyn std::error::Error>> {
+    debug!("→ Checking whether local OSDs are ok-to-stop on {}", node_name);
+    let check_cmd = if user == "root" {
+        r#"
+osds=$(basename -a /var/lib/ceph/osd/ceph-* 2>/dev/null | cut -d- -f2)
+
+if [ -z "$osds" ]; then
+    echo "No local OSDs found"
+    exit 0
+fi
+
+for osd in $osds; do
+    ceph osd ok-to-stop "$osd" | jq -e '.ok_to_stop == true' >/dev/null || {
+        echo "OSD $osd is not ok-to-stop"
+        exit 1
+    }
+done
+"#
+    } else {
+        r#"
+osds=$(basename -a /var/lib/ceph/osd/ceph-* 2>/dev/null | cut -d- -f2)
+
+if [ -z "$osds" ]; then
+    echo "No local OSDs found"
+    exit 0
+fi
+
+for osd in $osds; do
+    sudo ceph osd ok-to-stop "$osd" | jq -e '.ok_to_stop == true' >/dev/null || {
+        echo "OSD $osd is not ok-to-stop"
+        exit 1
+    }
+done
+"#
+    };
+
+    let output = Command::new("ssh")
+        .args([
+            "-o", "StrictHostKeyChecking=accept-new",
+            "-o", "BatchMode=yes",
+            ssh_target,
+            check_cmd,
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        error!("✗ One or more OSDs on {} are not ok-to-stop: {} {}", node_name, stdout.trim(), stderr.trim());
+        return Err(format!("Ceph cluster does not allow stopping node {}", node_name).into());
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    if stdout.contains("No local OSDs found") {
+        info!("→ No local OSDs found on {}, skipping ok-to-stop checks", node_name);
+    } else {
+        info!("→ All local OSDs on {} are ok-to-stop", node_name);
+    }
+
+    debug!("→ Enabling maintenance mode for node {}", node_name);
+
+    let maintenance_cmd = if user == "root" {
+        format!("ceph osd set-group noout {}", node_name)
+    } else {
+        format!("sudo ceph osd set-group noout {}", node_name)
+    };
+
+    let output = Command::new("ssh")
+        .args([
+            "-o", "StrictHostKeyChecking=accept-new",
+            "-o", "BatchMode=yes",
+            ssh_target,
+            &maintenance_cmd,
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        error!("✗ Failed to enable ceph maintenance mode for {}: {}", node_name, stderr.trim());
+        return Err(format!("Failed to enable ceph maintenance mode for {}", node_name).into());
+    }
+
+    info!("→ Set noout for ceph maintenance for host {}", node_name);
+
+    Ok(())
+}
+
+pub fn exec_disable_ceph_maintenance(user: &str, ssh_target: &str, node_name: &str) -> Result<(), Box<dyn std::error::Error>> {
+    debug!("→ Disabling maintenance mode for node {}", node_name);
+    let remote_cmd = if user == "root" {
+        format!("ceph osd unset-group noout {}", node_name)
+    } else {
+        format!("sudo ceph osd unset-group noout {}", node_name)
+    };
+
+    let output = Command::new("ssh")
+        .args([
+            "-o", "StrictHostKeyChecking=accept-new",
+            "-o", "BatchMode=yes",
+            ssh_target,
+            &remote_cmd,
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        error!(
+            "✗ Failed to disable ceph maintenance mode for {}: {}",
+            node_name,
+            stderr.trim()
+        );
+        return Err(format!(
+            "Failed to disable ceph maintenance mode for {}",
+            node_name
+        )
+        .into());
+    }
+
+    info!("→ Removed noout for ceph maintenance from host {}", node_name);
+
+    Ok(())
+}
+
+pub fn exec_check_ceph_mon_ok_to_stop(user: &str, ssh_target: &str, node_name: &str) -> Result<(), Box<dyn std::error::Error>> {
+    debug!("→ Checking whether local MONs are ok-to-stop on {}", node_name);
+    let check_cmd = if user == "root" {
+        r#"
+if ! systemctl is-active --quiet ceph-mon@$(hostname); then
+    echo "No local MON found"
+    exit 0
+fi
+
+ceph mon ok-to-stop $(hostname) | jq -e '.ok_to_stop == true' >/dev/null || {
+    echo "MON $(hostname) is not ok-to-stop"
+    exit 1
+}
+"#
+    } else {
+        r#"
+if ! systemctl is-active --quiet ceph-mon@$(hostname); then
+    echo "No local MON found"
+    exit 0
+fi
+
+sudo ceph mon ok-to-stop $(hostname) | jq -e '.ok_to_stop == true' >/dev/null || {
+    echo "MON $(hostname) is not ok-to-stop"
+    exit 1
+}
+"#
+    };
+
+    let output = Command::new("ssh")
+        .args([
+            "-o", "StrictHostKeyChecking=accept-new",
+            "-o", "BatchMode=yes",
+            ssh_target,
+            check_cmd,
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        error!("✗ MON on {} is not ok-to-stop: {} {}", node_name, stdout.trim(), stderr.trim());
+        return Err(format!("Ceph cluster does not allow stopping MON on {}", node_name).into());
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    if stdout.contains("No local MON found") {
+        info!("→ No local MON found on {}, skipping ok-to-stop checks", node_name);
+    } else {
+        info!("→ Local MON on {} is ok-to-stop", node_name);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Feature: Add ceph maintenance support

This feature enables automated detection and validation of OSDs and Mons on a target node before being patched. It validates in the OSDs and potentials Mons are valid to be stopped and sets the node to noout before proceeding when a reboot is required.

Co-worked: @CarstenFeuls-credativ <Carsten.Feuls@credativ.de>
Sponsored-by: @credativ <https://credativ.de/>
Fixes: #3